### PR TITLE
Prevent crash on connection error to URL

### DIFF
--- a/lib/handlers/url.js
+++ b/lib/handlers/url.js
@@ -50,6 +50,7 @@ function createUrlHandler (
       logger.debug(`serving remote ${url}`)
     })
 
+    handle.on('error', onError)
     handle.end()
 
     function onError (err) {

--- a/lib/handlers/url.js
+++ b/lib/handlers/url.js
@@ -55,6 +55,7 @@ function createUrlHandler (
 
     function onError (err) {
       logger.error(`error while serving remote ${url}: ${err}`, err)
+      res.statusCode = 500
       res.end(err.toString())
     }
   }


### PR DESCRIPTION
Currently in the frock-static URL handler, the server will panic if there's a connection error trying to retrieve the URL. This updates the handler to return a 500 response and keep running.