### PR TITLE
Replace ReadStream.end with ReadStream.close

### DIFF
--- a/lib/handlers/dir.js
+++ b/lib/handlers/dir.js
@@ -28,7 +28,7 @@ function createDirHandler (logger, {dir}) {
 
     res.setHeader('Content-Type', mime.contentType(path.extname(localPath)))
 
-    res.on('close', () => handler.end())
+    res.on('close', () => handler.close())
 
     handler.on('error', onError)
     handler.pipe(res)

--- a/lib/handlers/file.js
+++ b/lib/handlers/file.js
@@ -40,7 +40,7 @@ function createFileHandler (
 
     res.setHeader('Content-Type', contentTypeHeader)
 
-    res.on('close', () => handle.end())
+    res.on('close', () => handle.close())
 
     handle.on('error', onError)
     handle.pipe(res)


### PR DESCRIPTION
Fixes `handle.end is not a function` exceptions in these handlers. Only writable streams have `.end()`.