### PR TITLE
Replace ReadStream.end with ReadStream.close, part 2

### DIFF
--- a/lib/handlers/url.js
+++ b/lib/handlers/url.js
@@ -43,7 +43,7 @@ function createUrlHandler (
       })
 
       remoteRes.on('error', onError)
-      res.on('close', () => remoteRes.end())
+      res.on('close', () => remoteRes.close())
 
       remoteRes.pipe(res)
 


### PR DESCRIPTION
Only writable streams have `end()`. The remote response is a read-only stream, so we need to use `close()` instead.

This fixes a file I missed in #6. 