### PR TITLE
close() does not exist on Readable, use destroy() instead

### DIFF
--- a/lib/handlers/url.js
+++ b/lib/handlers/url.js
@@ -43,7 +43,7 @@ function createUrlHandler (
       })
 
       remoteRes.on('error', onError)
-      res.on('close', () => remoteRes.close())
+      res.on('close', () => remoteRes.destroy())
 
       remoteRes.pipe(res)
 


### PR DESCRIPTION
Fixes a mistake in #7 : `remoteRes` is not a ReadStream and does not have a `close()` method. It is a Readable and has a `destroy()` method.